### PR TITLE
initial fixes for named parameter generation

### DIFF
--- a/ramlfications/models/base.py
+++ b/ramlfications/models/base.py
@@ -136,7 +136,6 @@ class BaseNamedParameter(object):
     desc         = attr.ib(repr=False)
     display_name = attr.ib(repr=False)
     example      = attr.ib(repr=False)
-    examples     = attr.ib(repr=False)
     max_length   = attr.ib(repr=False, validator=string_type_parameter)
     maximum      = attr.ib(repr=False, validator=integer_number_type_parameter)
     min_length   = attr.ib(repr=False, validator=string_type_parameter)
@@ -145,7 +144,6 @@ class BaseNamedParameter(object):
                            validator=string_type_parameter)
     pattern      = attr.ib(repr=False, default=None,
                            validator=string_type_parameter)
-    repeat       = attr.ib(repr=False, default=False)
 
 
 @attr.s
@@ -184,3 +182,15 @@ class BaseParameter(BaseNamedParameter, BaseParameterAttrs):
         ``ramlfications`` library.
     :param list errors: List of RAML validation errors.
     """
+
+
+@attr.s
+class BaseParameterRaml08(object):
+    """TODO: writeme"""
+    repeat = attr.ib(repr=False)
+
+
+@attr.s
+class BaseParameterRaml10(object):
+    """TODO: writeme"""
+    examples = attr.ib(repr=False)

--- a/tests/integration/data_types/test_examples_10.py
+++ b/tests/integration/data_types/test_examples_10.py
@@ -19,7 +19,7 @@ from tests.base import RAML_10
 def api():
     ramlfile = os.path.join(RAML_10, "data-type-examples.raml")
     loaded_raml = load_file(ramlfile)
-    conffile = os.path.join(RAML_10, "test_config.ini")
+    conffile = os.path.join(RAML_10, "test-config.ini")
     config = setup_config(conffile)
     return parse_raml(loaded_raml, config)
 


### PR DESCRIPTION
Still a lot of failures - but from the adding of the `examples` feature, and not `root` interpolation.
